### PR TITLE
Addition of the ability to decorate with custom fixed tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,11 @@ prometheusConfig:
       matchName: "testName.value"
       labels: {"method":"${0}", "value":"${1}"}
 ```
+
+### Static tag addition
+Adding static tags from the client is considered and anti pattern and should be avoided since it is the prometheus 
+server in the job configuration that should do this. That said, in the advent of OpenMetrics this might be something 
+that could help specially if prometheus is not the scraper. Use this at your own discretion
+
+prometheusConfig:
+    customLabels: {"mylabel":"myvalue"}

--- a/src/main/java/com/expediagroup/dropwizard/prometheus/GlobalLabelSampleBuilderDecorator.java
+++ b/src/main/java/com/expediagroup/dropwizard/prometheus/GlobalLabelSampleBuilderDecorator.java
@@ -1,0 +1,41 @@
+package com.expediagroup.dropwizard.prometheus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
+
+/**
+ * In prometheus land this is an anti-pattern. Ideally global labels should come from the prometheus server
+ * which can be setup to re-label or enrich at scrapping time. It is considered an anti-pattern to use the client
+ * side to enrich or add fixed labels.. That said with the advent of open metrics it is not always prometheus that
+ * scrapes and there are certain times where the values need to come from the client.
+ *
+ * Dropwizard makes this particulary hard because there are no labels to begin with, the custom mapping namer can fix
+ * some of this but that one just assumes that the values come from the actual metric name.
+ *
+ * This class just adds fixed tags to every sample.
+ */
+public class GlobalLabelSampleBuilderDecorator implements SampleBuilder {
+
+    SampleBuilder decorate;
+    ArrayList<String> labelNames;
+    ArrayList<String> labelValues;
+
+    public GlobalLabelSampleBuilderDecorator(SampleBuilder decorate, Map<String, String> labels){
+        this.decorate = decorate;
+        this.labelNames = new ArrayList<>(labels.keySet());
+        this.labelValues = new ArrayList<>(labels.values());
+    }
+
+    @Override
+    public Collector.MetricFamilySamples.Sample createSample(String dropwizardName, String nameSuffix, List<String> additionalLabelNames, List<String> additionalLabelValues, double value) {
+        List<String> decoratedlabelnames = new ArrayList<>(additionalLabelNames);
+        decoratedlabelnames.addAll(labelNames);
+        List<String> decoratedlabelvalues = new ArrayList<>(additionalLabelValues);
+        decoratedlabelvalues.addAll(labelValues);
+        return decorate.createSample(dropwizardName, nameSuffix, decoratedlabelnames, decoratedlabelvalues, value);
+    }
+}

--- a/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundle.java
+++ b/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundle.java
@@ -109,6 +109,9 @@ public class PrometheusBundle<T extends Configuration>  implements ConfiguredBun
             sampleBuilder = new DefaultSampleBuilder();
         }
 
+        if (config.customLabels != null && !config.customLabels.isEmpty()){
+            sampleBuilder = new GlobalLabelSampleBuilderDecorator(sampleBuilder, config.customLabels);
+        }
         return new DropwizardExports(registry, sampleBuilder);
     }
 }

--- a/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundleConfig.java
+++ b/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundleConfig.java
@@ -27,7 +27,10 @@ import lombok.Data;
 public class PrometheusBundleConfig {
     String scrapePath = "/metrics";
     List<MapperConfig> mapperConfig = Collections.emptyList();
-
+    //Adding custom labels from a client is considered and anti-pattern since it is prometheus that should add such
+    //labels when it scrapes... that said, there are edge use cases where global labels need to be added. Use this
+    //feature sparingly
+    Map<String, String> customLabels = Collections.emptyMap();
 
     @Data
     public static class MapperConfig{

--- a/src/test/java/com/expediagroup/dropwizard/prometheus/GlobalLabelSampleBuilderDecoratorTest.java
+++ b/src/test/java/com/expediagroup/dropwizard/prometheus/GlobalLabelSampleBuilderDecoratorTest.java
@@ -1,0 +1,66 @@
+package com.expediagroup.dropwizard.prometheus;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
+
+public class GlobalLabelSampleBuilderDecoratorTest {
+
+    private DefaultSampleBuilder defaultSampleBuilder = new DefaultSampleBuilder();
+
+    @Test
+    public void testSimpleLabel(){
+        Map<String, String> fixedlabels = new HashMap<>();
+        fixedlabels.put("app_name", "my_app");
+
+        GlobalLabelSampleBuilderDecorator decorator = new GlobalLabelSampleBuilderDecorator(defaultSampleBuilder, fixedlabels);
+
+        Collector.MetricFamilySamples.Sample sample = decorator.createSample("com.test.count", "", Collections.emptyList(), Collections.emptyList(), 200);
+
+        Assertions.assertThat(sample).isNotNull();
+        Assertions.assertThat(sample.labelNames).isNotNull().hasSize(1).contains("app_name");
+        Assertions.assertThat(sample.labelValues).isNotNull().hasSize(1).contains("my_app");
+    }
+
+    @Test
+    public void testMultiLabel(){
+        Map<String, String> fixedlabels = new HashMap<>();
+        fixedlabels.put("label1", "value1");
+        fixedlabels.put("label2", "value2");
+
+        GlobalLabelSampleBuilderDecorator decorator = new GlobalLabelSampleBuilderDecorator(defaultSampleBuilder, fixedlabels);
+
+        Collector.MetricFamilySamples.Sample sample = decorator.createSample("com.test.count", "", Collections.emptyList(), Collections.emptyList(), 200);
+
+        Assertions.assertThat(sample).isNotNull();
+        Assertions.assertThat(sample.labelNames).isNotNull().hasSize(2).contains("label1", "label2");
+        Assertions.assertThat(sample.labelValues).isNotNull().hasSize(2).contains("value1", "value2");
+    }
+
+    @Test
+    public void testAdditive(){
+        Map<String, String> fixedlabels = new HashMap<>();
+        fixedlabels.put("label1", "value1");
+        fixedlabels.put("label2", "value2");
+
+        List<String> dynamiclabelnames = Arrays.asList(new String[]{"john", "jane"});
+        List<String> dynamiclabelvalues = Arrays.asList(new String[]{"doe", "dove"});
+
+        GlobalLabelSampleBuilderDecorator decorator = new GlobalLabelSampleBuilderDecorator(defaultSampleBuilder, fixedlabels);
+
+        Collector.MetricFamilySamples.Sample sample = decorator.createSample("com.test.count", "", dynamiclabelnames, dynamiclabelvalues, 200);
+
+        Assertions.assertThat(sample).isNotNull();
+        Assertions.assertThat(sample.labelNames).isNotNull().hasSize(4).contains("label1", "label2", "john", "jane");
+        Assertions.assertThat(sample.labelValues).isNotNull().hasSize(4).contains("value1", "value2", "doe", "dove");
+    }
+}

--- a/src/test/java/com/expediagroup/dropwizard/prometheus/TestPrometheusBundle.java
+++ b/src/test/java/com/expediagroup/dropwizard/prometheus/TestPrometheusBundle.java
@@ -44,7 +44,7 @@ public class TestPrometheusBundle {
         int port = DROPWIZARD.getAdminPort();
         Client client = DROPWIZARD.client();
 
-        String scrape = client.target("http://localhost:"+Integer.toString(port)+"/metrics")
+        String scrape = client.target("http://localhost:"+ port +"/metrics")
         .request().get(String.class);
 
         Assertions.assertThat(scrape)


### PR DESCRIPTION
# prometheus dropwizard bundle PR

_&lt;High level description of the PR&gt;_
This PR adds the ability to decorate the metrics with a set of custom fixed tags that do not resolve from the metric name. 

### Added
* Ability to configure the applcation to use custom tags
* Custom decorator to add the tags via the SampleBuilder interface
* Tests

### Changed
* Readme changes describing the feature