### PR TITLE
Upgrade various dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,27 +49,28 @@
         <!-- JaCoCo Coverage -->
         <coverage.line>0.80</coverage.line>
 
-        <dropwizard.version>2.0.2</dropwizard.version>
-        <metrics4.version>4.1.2</metrics4.version>
-        <prometheus.version>0.8.0</prometheus.version>
+        <dropwizard.version>2.0.28</dropwizard.version>
+        <metrics4.version>4.1.29</metrics4.version>
+        <prometheus.version>0.15.0</prometheus.version>
 
         <!-- Testing -->
-        <junit.jupiter.version>5.6.0</junit.jupiter.version>
-        <assert4j.version>3.15.0</assert4j.version>
+        <junit.jupiter.version>5.8.2</junit.jupiter.version>
+        <assert4j.version>3.21.0</assert4j.version>
 
         <!-- Utilities -->
-        <lombok.version>1.18.12</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
 
         <!-- Plugins -->
-        <compiler.pluginVersion>3.8.1</compiler.pluginVersion>
-        <enforcer.pluginVersion>3.0.0-M3</enforcer.pluginVersion>
-        <release.pluginVersion>3.0.0-M1</release.pluginVersion>
+        <compiler.pluginVersion>3.9.0</compiler.pluginVersion>
+        <enforcer.pluginVersion>3.0.0</enforcer.pluginVersion>
+        <javadoc.pluginVersion>3.3.2</javadoc.pluginVersion>
+        <release.pluginVersion>3.0.0-M5</release.pluginVersion>
         <source.pluginVersion>3.2.1</source.pluginVersion>
-        <surefire.pluginVersion>3.0.0-M4</surefire.pluginVersion>
+        <surefire.pluginVersion>3.0.0-M5</surefire.pluginVersion>
         <preparationGoals>clean install</preparationGoals>
 
         <!-- OSSRH -->
-        <nexusStaging.pluginVersion>1.6.8</nexusStaging.pluginVersion>
+        <nexusStaging.pluginVersion>1.6.12</nexusStaging.pluginVersion>
     </properties>
 
     <dependencyManagement>
@@ -214,7 +215,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${javadoc.pluginVersion}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
# prometheus dropwizard bundle PR

Upgrade various dependencies.

Based on [Prometheus Release Notes](https://github.com/prometheus/client_java/releases), the only breaking change called out was in [0.12.0](https://github.com/prometheus/client_java/releases/tag/parent-0.12.0) but on a module that we don't use (simpleclient_hotspot).

### Changed
* Update dropwizard: `2.0.2` -> `2.0.28`
* Update metrics4: `4.1.2` -> `4.1.29`
* Update prometheus: `0.8.0` -> `0.15.0`


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 