### PR TITLE
fix: Announce end of support for this bundle, mark classes deprecated for visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# dropwizard-prometheus-bundle
+# dropwizard-prometheus-bundle (DEPRECATED)
 [![Release](https://github.com/ExpediaGroup/dropwizard-prometheus-bundle/actions/workflows/release.yml/badge.svg)](https://github.com/ExpediaGroup/dropwizard-prometheus-bundle/actions/workflows/release.yml)
+
+**DEPRECATED: We no longer maintain dropwizard-prometheus-bundle. If you have questions or concerns, please open an
+issue or fork this repository.**
 
 This bundle allows for a quick drop-in enablement of prometheus exposition format in dropwizard applications. The bundle
 allows a user to integrate and configure the prometheus dropwizard metrcis bridge and the exposition servlet into a 

--- a/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundle.java
+++ b/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundle.java
@@ -36,7 +36,7 @@ import io.prometheus.client.exporter.MetricsServlet;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+ * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-prometheus-bundle/blob/master/README.md">README.md</a>
  */
 @Slf4j
 @Deprecated
@@ -46,7 +46,7 @@ public class PrometheusBundle<T extends Configuration>  implements ConfiguredBun
     CollectorRegistry prometheusRegistry;
 
     /**
-    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-prometheus-bundle/blob/master/README.md">README.md</a>
     */
     @Deprecated
     public PrometheusBundle(Function<T, PrometheusBundleConfig> mapperFn){
@@ -55,7 +55,7 @@ public class PrometheusBundle<T extends Configuration>  implements ConfiguredBun
     }
 
     /**
-    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-prometheus-bundle/blob/master/README.md">README.md</a>
     */
     @Deprecated
     public PrometheusBundle(Function<T, PrometheusBundleConfig> mapperFn, CollectorRegistry customRegistry){

--- a/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundle.java
+++ b/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundle.java
@@ -35,17 +35,29 @@ import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
 import io.prometheus.client.exporter.MetricsServlet;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+ */
 @Slf4j
+@Deprecated
 public class PrometheusBundle<T extends Configuration>  implements ConfiguredBundle<T> {
 
     Function<T, PrometheusBundleConfig> configMapperFn;
     CollectorRegistry prometheusRegistry;
 
+    /**
+    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+    */
+    @Deprecated
     public PrometheusBundle(Function<T, PrometheusBundleConfig> mapperFn){
         configMapperFn = mapperFn;
         prometheusRegistry = CollectorRegistry.defaultRegistry;
     }
 
+    /**
+    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+    */
+    @Deprecated
     public PrometheusBundle(Function<T, PrometheusBundleConfig> mapperFn, CollectorRegistry customRegistry){
         configMapperFn = mapperFn;
         prometheusRegistry = customRegistry;

--- a/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundleConfig.java
+++ b/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundleConfig.java
@@ -25,8 +25,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+* @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+*/
 @Getter
 @Setter
+@Deprecated
 public class PrometheusBundleConfig {
 
     private static final String DEFAULT_SCRAPE_PATH = "/metrics";
@@ -47,10 +51,18 @@ public class PrometheusBundleConfig {
      */
     Map<String, String> customLabels = Collections.emptyMap();
 
+    /**
+    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+    */
+    @Deprecated
     public PrometheusBundleConfig() {
         this.scrapePath = DEFAULT_SCRAPE_PATH;
     }
 
+    /**
+    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+    */
+    @Deprecated
     public PrometheusBundleConfig(String scrapePath) {
         this.scrapePath = scrapePath;
     }

--- a/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundleConfig.java
+++ b/src/main/java/com/expediagroup/dropwizard/prometheus/PrometheusBundleConfig.java
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
-* @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+* @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-prometheus-bundle/blob/master/README.md">README.md</a>
 */
 @Getter
 @Setter
@@ -52,7 +52,7 @@ public class PrometheusBundleConfig {
     Map<String, String> customLabels = Collections.emptyMap();
 
     /**
-    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-prometheus-bundle/blob/master/README.md">README.md</a>
     */
     @Deprecated
     public PrometheusBundleConfig() {
@@ -60,7 +60,7 @@ public class PrometheusBundleConfig {
     }
 
     /**
-    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-template-config/blob/master/README.md">README.md</a>
+    * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-prometheus-bundle/blob/master/README.md">README.md</a>
     */
     @Deprecated
     public PrometheusBundleConfig(String scrapePath) {


### PR DESCRIPTION
# prometheus dropwizard bundle PR

The Expedia Group team behind the dropwizard-prometheus-bundle will no longer be supporting it.

The public-facing classes are marked as deprecated so as to alert developers that use the package of its new state.

### Added
* Message in README about the bundle being marked deprecated

### Changed
* marked the PrometheusBundle class as `@Deprecated`
* marked the PrometheusBundleConfig class as `@Deprecated`

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 